### PR TITLE
Replace assertion with simple log

### DIFF
--- a/Sources/SRGAppearance/SRGFont.m
+++ b/Sources/SRGAppearance/SRGFont.m
@@ -221,9 +221,12 @@ __attribute__((constructor)) static void SRGAppearanceRegisterFonts(void)
 {
     NSArray<NSURL *> *fontFileURLs = [SWIFTPM_MODULE_BUNDLE URLsForResourcesWithExtension:@"ttf" subdirectory:nil];
     for (NSURL *fileURL in fontFileURLs) {
-        __unused BOOL success = CTFontManagerRegisterFontsForURL((CFURLRef)fileURL, kCTFontManagerScopeProcess, NULL);
-        NSCAssert(success, @"The SRG SSR font could not be registered. Please ensure only SRG Appearance registers "
-                  "this font (check font declarations in your application Info.plist)");
+        BOOL success = CTFontManagerRegisterFontsForURL((CFURLRef)fileURL, kCTFontManagerScopeProcess, NULL);
+        if (! success) {
+            NSLog(@"The SRG SSR font could not be registered. Please ensure only SRG Appearance registers "
+                  "this font (check font declarations in your application Info.plist). You can ignore this "
+                  "message in unit tests.");
+        }
     }
 }
 


### PR DESCRIPTION
# Pull request

## Description

This PR avoids crashing unit tests during font registration.

## Changes made

I replaced the assertion with an `NSLog`. Using `NSLog` is in general bad practice but here this is just for warning purposes. Adding a dependency on `SRGLogger` or using `os_log` seemed also a bit too much.